### PR TITLE
Adding database cleaner.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN echo "gem: --no-document" > ~/.gemrc && \
 COPY . $WORKDIR
 COPY docker-assets/entrypoint /usr/bin
 COPY docker-assets/run_scheduler /usr/bin
+COPY docker-assets/run_db_cleaner /usr/bin
 
 RUN chgrp -R 0 $WORKDIR && \
     chmod -R g=u $WORKDIR

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'prometheus_exporter', '~> 0.4.5'
 
 gem 'topological_inventory-core', '~> 1.1.5'
 
-group :development do
+group :development, :test do
   gem 'rspec-rails',         '~>3.8'
   gem 'rubocop',             '~>0.69.0', :require => false
   gem 'rubocop-performance', '~>1.3',    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'manageiq-messaging',  '~> 0.1.2'
 gem 'optimist',            '~> 3.0'
 gem 'prometheus_exporter', '~> 0.4.5'
 
-gem 'topological_inventory-core', '~> 1.1.5'
+gem 'topological_inventory-core', '~> 1.1.7'
 
 group :development, :test do
   gem 'rspec-rails',         '~>3.8'

--- a/bin/topological_inventory-db_cleaner
+++ b/bin/topological_inventory-db_cleaner
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH << File.expand_path("../lib", __dir__)
-require "bundler/setup"
-require "topological_inventory/core/ar_helper"
+require 'bundler/setup'
+require 'topological_inventory/core/ar_helper'
 
 TopologicalInventory::Core::ArHelper.database_yaml_path = Pathname.new(__dir__).join("../config/database.yml")
 TopologicalInventory::Core::ArHelper.load_environment!
 
-require "topological_inventory/scheduler/database_tools"
+require 'topological_inventory/scheduler/database_tools'
 
-TopologicalInventory::Scheduler::DatabaseTools.remove_old_records
+TopologicalInventory::Scheduler::DatabaseTools.new.remove_old_records

--- a/bin/topological_inventory-db_cleaner
+++ b/bin/topological_inventory-db_cleaner
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+require "bundler/setup"
+require "topological_inventory/core/ar_helper"
+
+TopologicalInventory::Core::ArHelper.database_yaml_path = Pathname.new(__dir__).join("../config/database.yml")
+TopologicalInventory::Core::ArHelper.load_environment!
+
+require "topological_inventory/scheduler/database_tools"
+
+TopologicalInventory::Scheduler::DatabaseTools.remove_old_records

--- a/docker-assets/run_db_cleaner
+++ b/docker-assets/run_db_cleaner
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+function write_encryption_key() {
+  echo "== Writing encryption key =="
+  cat > $WORKDIR/v2_key << KEY
+---
+:algorithm: aes-256-cbc
+:key: ${ENCRYPTION_KEY}
+KEY
+}
+
+function check_svc_status() {
+  local SVC_NAME=$1 SVC_PORT=$2
+
+  [[ $# -lt 2 ]] && echo "Error something seems wrong, we need at least two parameters to check service status" && exit 1
+
+  echo "== Checking ${SVC_NAME}:$SVC_PORT status =="
+
+  while true; do
+    ncat ${SVC_NAME} ${SVC_PORT} < /dev/null && break
+    sleep 5
+  done
+  echo "${SVC_NAME}:${SVC_PORT} - accepting connections"
+}
+
+write_encryption_key
+
+# Wait for postgres to be ready
+check_svc_status $DATABASE_HOST $DATABASE_PORT
+
+bin/topological_inventory-db_cleaner

--- a/lib/topological_inventory/scheduler/database_tools.rb
+++ b/lib/topological_inventory/scheduler/database_tools.rb
@@ -1,0 +1,24 @@
+require 'topological_inventory/scheduler/logging'
+require 'active_support/core_ext/integer/time'
+
+module TopologicalInventory
+  module Scheduler
+    class DatabaseTools
+      include Logging
+
+      REFRESH_STATES_TIME_THRESHOLD = 1.week.freeze
+
+      def remove_old_records
+        threshold = DateTime.now - REFRESH_STATES_TIME_THRESHOLD  
+
+        logger.info("DatabaseTools: Deleting RefreshState records older than #{threshold} has started...")
+
+        RefreshState.where('updated_at <= ?', threshold).delete_all
+
+        logger.info("DatabaseTools: Deleting RefreshState records older than #{threshold} has finished...")
+      rescue => e
+        logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@ end
 require "bundler/setup"
 require "rspec"
 
+ENV["RAILS_ENV"] ||= "test"
+
+raise "Specs must be run in test environment" if ENV["RAILS_ENV"] != "test"
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/topological_inventory/scheduler/database_tools_spec.rb
+++ b/spec/topological_inventory/scheduler/database_tools_spec.rb
@@ -1,0 +1,104 @@
+require 'topological_inventory/core/ar_helper'
+TopologicalInventory::Core::ArHelper.load_environment!
+
+require "topological_inventory/scheduler/database_tools"
+
+RSpec.describe TopologicalInventory::Scheduler::DatabaseTools do
+  subject { described_class }
+
+  describe "#remove_old_records" do
+    let(:uuids) { ['f41743e5-639b-411f-89a7-ed1a4cb9d860', 'c2cb467d-156f-41bb-bdab-a7d311b54f1b'] }
+    let(:tenant)   { Tenant.create(:name => 'testing_tenant', :external_tenant => 'testing') }
+    let(:source)   { Source.create(:uid => '31b5338b-685d-4056-ba39-d00b4d7f19cc', :tenant_id => tenant.id) }
+    let(:threshold) { TopologicalInventory::Scheduler::DatabaseTools::REFRESH_STATES_TIME_THRESHOLD }
+
+    before(:all) do
+      Tenant.delete_all
+      Source.delete_all
+    end
+
+    after(:each) do
+      Tenant.delete_all
+      Source.delete_all
+    end
+
+    it 'removes old records' do
+      rs  = create_refresh_state(source.id, uuids[0])
+      rs.updated_at = Time.now.utc - threshold
+      rs.save
+      create_refresh_state_part(rs.id, uuids[0])
+      create_refresh_state_part(rs.id, uuids[1])
+
+      expect(RefreshState.count).to eq(1)
+      expect(RefreshStatePart.count).to eq(2)
+
+      subject.remove_old_records
+
+      expect(RefreshState.count).to eq(0)
+      expect(RefreshStatePart.count).to eq(0)
+    end
+
+    it 'does not remove younger records' do
+      rs  = create_refresh_state(source.id, uuids[0])
+      create_refresh_state_part(rs.id, uuids[0])
+
+      expect(RefreshState.count).to eq(1)
+      expect(RefreshStatePart.count).to eq(1)
+
+      subject.remove_old_records
+
+      expect(RefreshState.count).to eq(1)
+      expect(RefreshStatePart.count).to eq(1)
+    end
+
+    it 'does not remove related objects' do
+      rs  = create_refresh_state(source.id, uuids[0])
+      rs.updated_at = Time.now.utc - threshold
+      rs.save
+      rsp = create_refresh_state_part(rs.id, uuids[0])
+      Vm.create(
+        :tenant_id             => tenant.id,
+        :source_id             => source.id,
+        :source_ref            => 'source_ref_test',
+        :refresh_state_part_id => rsp.id
+      )
+      Host.create(
+        :tenant_id             => tenant.id,
+        :source_id             => source.id,
+        :source_ref            => 'source_ref_test',
+        :refresh_state_part_id => rsp.id
+      )
+
+      expect(Vm.count).to eq(1)
+      expect(Host.count).to eq(1)
+      expect(RefreshState.count).to eq(1)
+      expect(RefreshStatePart.count).to eq(1)
+
+      subject.remove_old_records
+
+      expect(Vm.count).to eq(1)
+      expect(Vm.first.refresh_state_part_id).to be_nil
+      expect(Host.count).to eq(1)
+      expect(Host.first.refresh_state_part_id).to be_nil
+      expect(RefreshState.count).to eq(0)
+      expect(RefreshStatePart.count).to eq(0)
+    end
+
+    def create_refresh_state(source_id, uuid)
+      RefreshState.create(
+        :source_id         => source_id,
+        :tenant_id         => tenant.id,
+        :uuid              => uuid,
+        :sweep_scope       => ['vms', 'hosts']
+      )
+    end
+
+    def create_refresh_state_part(refresh_state_id, uuid)
+      RefreshStatePart.create(
+        :refresh_state_id => refresh_state_id,
+        :tenant_id        => tenant.id,
+        :uuid             => uuid
+      )
+    end
+  end
+end


### PR DESCRIPTION
Adding a new `DatabaseTools` class with `#remove_old_records` method for clearing the old records from `refresh_states` and `refresh_state_parts` tables. I also modified the `spec_helper` and `Gemfile` files for running my new spec.

- [x] Depends on https://github.com/RedHatInsights/topological_inventory-core/pull/205
- e2e_deploy: https://github.com/RedHatInsights/e2e-deploy/pull/2244

---

[TPINVTRY-1080](https://projects.engineering.redhat.com/browse/TPINVTRY-1080)