### PR TITLE
Revert cloudwatchlogger to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths('bundler-inject')[0], 'bundler-inject') rescue nil
 
-gem 'cloudwatchlogger',    '~> 0.2'
+gem 'cloudwatchlogger',    '~> 0.2.1'
 gem 'manageiq-loggers',    '~> 0.5.0'
 gem 'manageiq-messaging',  '~> 0.1.2'
 gem 'optimist',            '~> 3.0'


### PR DESCRIPTION
Issue: https://github.com/RedHatInsights/topological_inventory-persister/issues/70

Cloudwatch 0.3.0 is not compatible: https://github.com/zshannon/cloudwatchlogger/issues/16