### PR TITLE
Scheduled tasks from available Sources only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'sources-api-client', '~> 3.0'
 gem 'topological_inventory-core', '~> 1.1.7'
 
 group :development, :test do
+  gem 'factory_bot',         '~>6.1'
   gem 'rspec-rails',         '~>3.8'
   gem 'rubocop',             '~>0.69.0', :require => false
   gem 'rubocop-performance', '~>1.3',    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'manageiq-messaging',  '~> 0.1.2'
 gem 'optimist',            '~> 3.0'
 gem 'prometheus_exporter', '~> 0.4.5'
 
+gem 'sources-api-client', '~> 3.0'
 gem 'topological_inventory-core', '~> 1.1.7'
 
 group :development, :test do

--- a/bin/topological_inventory-scheduler
+++ b/bin/topological_inventory-scheduler
@@ -10,11 +10,16 @@ def parse_args
   Optimist.options do
     opt :queue_host, "Kafka messaging: hostname or IP", :type => :string, :default => ENV["QUEUE_HOST"] || "localhost"
     opt :queue_port, "Kafka messaging: port", :type => :integer, :default => (ENV["QUEUE_PORT"] || 9092).to_i
+    opt :sources_scheme, "Sources API scheme", :type => :string, :default => ENV["SOURCES_SCHEME"] || "http"
+    opt :sources_host, "Sources API host name", :type => :string, :default => ENV["SOURCES_HOST"]
+    opt :sources_port, "Sources API port", :type => :integer, :default => ENV["SOURCES_PORT"].to_i
+
   end
 end
 
 def check_args(args)
-  %i[queue_host queue_port].each do |arg|
+  %i[queue_host queue_port
+     sources_scheme sources_host sources_port].each do |arg|
     Optimist.die arg, "can't be blank" if args[arg].blank?
     Optimist.die arg, "can't be zero" if arg.to_s.index('port').present? && args[arg].zero?
   end
@@ -25,6 +30,11 @@ check_args(args)
 
 TopologicalInventory::Core::ArHelper.database_yaml_path = Pathname.new(__dir__).join("../config/database.yml")
 TopologicalInventory::Core::ArHelper.load_environment!
+
+SourcesApiClient.configure do |config|
+  config.scheme = args[:sources_scheme] || "http"
+  config.host   = "#{args[:sources_host]}:#{args[:sources_port]}"
+end
 
 begin
   scheduler_worker = TopologicalInventory::Scheduler::Worker.new(:host => args[:queue_host], :port => args[:queue_port])

--- a/lib/topological_inventory/scheduler/sources_api_client.rb
+++ b/lib/topological_inventory/scheduler/sources_api_client.rb
@@ -1,0 +1,38 @@
+require 'sources-api-client'
+
+module TopologicalInventory
+  module Scheduler
+    class SourcesApiClient < ::SourcesApiClient::ApiClient
+      STATUS_AVAILABLE, STATUS_UNAVAILABLE, STATUS_UNKNOWN = %w[available unavailable unknown].freeze
+
+      def initialize
+        super(::SourcesApiClient::Configuration.default)
+        self.api = ::SourcesApiClient::DefaultApi.new(self)
+
+        @sources_status = {}
+      end
+
+      def source_available?(source_id, identity)
+        @sources_status[source_id] = get_source_status(source_id, identity) if @sources_status[source_id].nil?
+
+        @sources_status[source_id] == STATUS_AVAILABLE
+      end
+
+      private
+
+      attr_accessor :api
+
+      def get_source_status(source_id, identity)
+        return STATUS_UNKNOWN if identity.try(:[], 'x-rh-identity').nil?
+
+        source = fetch_source(source_id, identity)
+        source&.availability_status || STATUS_UNAVAILABLE
+      end
+
+      # TODO: Optimize, group sources by tenant
+      def fetch_source(source_id, identity)
+        api.show_source(source_id.to_s, :header_params => identity)
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/scheduler/worker.rb
+++ b/lib/topological_inventory/scheduler/worker.rb
@@ -1,5 +1,6 @@
 require 'manageiq-messaging'
 require 'topological_inventory/scheduler/logging'
+require 'topological_inventory/scheduler/sources_api_client'
 
 module TopologicalInventory
   module Scheduler
@@ -28,18 +29,25 @@ module TopologicalInventory
 
       def service_instance_refresh(tasks)
         logger.info('ServiceInstance#refresh - Started')
-        payload = {}
+        payload, skipped = {}, {}
 
-        tasks.each do |task|
+        tasks.find_each do |task|
           # grouping requests by Source
           # - tasks are ordered by source_id
-          if payload[:source_id].present? && payload[:source_id] != task.source_id
+          if payload[:source_id].present? && payload[:source_id] != task.source_id.to_s
             send_payload(payload)
-            payload = {}
+            log_skipped_tasks(skipped)
+            payload, skipped = {}, {}
+          end
+
+          unless source_available?(task)
+            skipped[task.source_id] ||= []
+            skipped[task.source_id] << task.id.to_s
+            next
           end
 
           log_with(task.forwardable_headers['x-rh-insights-request-id']) do
-            logger.info("ServiceInstance#refresh - Task(id: #{task.id}), ServiceInstance(source_ref: #{task.target_source_ref}), Source(id: #{task.source_id}")
+            logger.debug("ServiceInstance#refresh - Task(id: #{task.id}), ServiceInstance(source_ref: #{task.target_source_ref}), Source(id: #{task.source_id}")
 
             payload[:source_id]  = task.source_id.to_s
             payload[:source_uid] = task.source_uid.to_s
@@ -55,6 +63,7 @@ module TopologicalInventory
 
         # sending remaining data
         send_payload(payload) if payload[:params].present?
+        log_skipped_tasks(skipped)
       rescue => e
         logger.error("ServiceInstance#refresh - Failed. Task(id: #{tasks_id(tasks).join(' | ')}). Error: #{e.message}, #{e.backtrace.join('\n')}")
       end
@@ -72,6 +81,16 @@ module TopologicalInventory
         tasks.pluck(:id)
       end
 
+      # TODO: Update task.status = 'error' without request_context immediately?
+      def source_available?(task)
+        return false if task.forwardable_headers.nil?
+
+        api_client.source_available?(task.source_id, task.forwardable_headers)
+      rescue => e
+        logger.error("ServiceInstance#refresh - Task(id: #{task.id}), Error: #{e.message}, #{e.backtrace.join('\n')}")
+        false
+      end
+
       def send_payload(payload)
         logger.info("ServiceInstance#refresh - publishing to kafka: Source(id: #{payload[:source_id]})...")
         messaging_client.publish_topic(
@@ -82,8 +101,18 @@ module TopologicalInventory
         logger.info("ServiceInstance#refresh - publishing to kafka: Source(id: #{payload[:source_id]})...Complete")
       end
 
+      def log_skipped_tasks(skipped)
+        skipped.each_pair do |source_id, tasks_id|
+          logger.warn("ServiceInstance#refresh - Skipped Tasks (id: #{tasks_id.join(' | ')}). Source is unavailable (id: #{source_id})")
+        end
+      end
+
       def messaging_client
         @messaging_client ||= ManageIQ::Messaging::Client.open(messaging_client_opts)
+      end
+
+      def api_client
+        @api_client ||= TopologicalInventory::Scheduler::SourcesApiClient.new
       end
 
       def default_messaging_opts

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,51 @@
+FactoryBot.define do
+  factory :service_instance do
+    initialize_with do
+      ServiceInstance.where(:source_ref => source_ref)
+                     .first_or_create(:name   => name,
+                                      :source => source,
+                                      :tenant => source.tenant)
+    end
+
+    name { "default" }
+    source { association(:source) }
+    source_ref { rand(1000).to_s }
+  end
+
+  factory :service_offering do
+    initialize_with do
+      ServiceOffering.where(:source_ref => source_ref)
+                     .first_or_create(:description => description,
+                                      :name        => name,
+                                      :source      => source,
+                                      :tenant      => source.tenant)
+    end
+
+    description { 'Test Service Offering' }
+    name { "default" }
+    source { association(:source) }
+    source_ref { rand(1000).to_s }
+  end
+
+  factory :source do
+    initialize_with do
+      Source.where(:uid => uid)
+            .first_or_create(:tenant => tenant)
+    end
+
+    tenant { association(:tenant) }
+    uid    { SecureRandom.uuid }
+  end
+
+  factory :tenant do
+    initialize_with do
+      Tenant.where(:name => name)
+            .first_or_create(:description     => description,
+                             :external_tenant => external_tenant)
+    end
+
+    name            { "default" }
+    description     { "Test tenant" }
+    external_tenant { rand(1000).to_s }
+  end
+end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,39 @@
+FactoryBot.define do
+  factory :task do
+    forwardable_headers { {'x-rh-insights-request-id' => rand(1000).to_s} }
+    source { association(:source) }
+    state { 'running' }
+    status { 'ok' }
+
+    factory :task_svc_offering do
+      initialize_with do
+        Task.where(:name => name)
+          .first_or_create(:forwardable_headers => forwardable_headers,
+                           :state               => state,
+                           :status              => status,
+                           :source              => service_offering.source,
+                           :target_type         => target_type,
+                           :target_source_ref   => service_offering.source_ref,
+                           :tenant              => source.tenant)
+      end
+
+      name { 'ServiceOffering#order' }
+      target_type { 'ServiceOffering' }
+    end
+
+    factory :task_svc_instance do
+      initialize_with do
+        Task.where(:name => name)
+            .first_or_create(:state             => state,
+                             :status            => status,
+                             :source            => service_instance.source,
+                             :target_type       => target_type,
+                             :target_source_ref => service_instance.source_ref,
+                             :tenant            => source.tenant)
+      end
+
+      name { 'ServiceInstance#refresh' }
+      target_type { 'ServiceInstance' }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,16 +8,23 @@ raise "Specs must be run in test environment" if ENV["RAILS_ENV"] != "test"
 
 require 'active_record/railtie'
 require 'action_controller/railtie'
+require 'factory_bot'
 require 'rspec/rails'
-
 require 'topological_inventory/core/ar_helper'
+require 'topological_inventory/scheduler/logging'
+
 TopologicalInventory::Core::ArHelper.database_yaml_path = Pathname.new(__dir__).join("../config/database.yml")
 TopologicalInventory::Core::ArHelper.load_environment!
 
-require "topological_inventory/scheduler/logging"
-TopologicalInventory::Scheduler.logger = Logger.new('/dev/null')
+# TopologicalInventory::Scheduler.logger = Logger.new('/dev/null')
 
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
+
   config.use_transactional_fixtures = true
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/topological_inventory/scheduler/worker_spec.rb
+++ b/spec/topological_inventory/scheduler/worker_spec.rb
@@ -12,7 +12,119 @@ RSpec.describe TopologicalInventory::Scheduler::Worker do
     end
   end
 
-  describe "#load_running_tasks" do
-    
+  context "with initialized db" do
+    before do
+      @tenants = [
+        create(:tenant, :name => 'Tenant 1'),
+        create(:tenant, :name => 'Tenant 2')
+      ]
+
+      @sources = [
+        create(:source, :tenant => @tenants[0]),
+        create(:source, :tenant => @tenants[1])
+      ]
+      @service_instances = [
+        create(:service_instance, :source_ref => '1', :source => @sources[0]),
+        create(:service_instance, :source_ref => '2', :source => @sources[1]),
+        create(:service_instance, :source_ref => '3', :source => @sources[0]),
+        create(:service_instance, :source_ref => '4', :source => @sources[0])
+      ]
+
+      @service_offerings = [
+        create(:service_offering, :source_ref => '1', :source => @sources[0])
+      ]
+
+      @tasks = [
+        create(:task_svc_instance, :name => 'task1', :state => 'completed', :service_instance => @service_instances[0]),
+        create(:task_svc_instance, :name => 'task2', :state => 'running', :service_instance => @service_instances[1]),
+        create(:task_svc_instance, :name => 'task3', :state => 'running', :service_instance => @service_instances[2]),
+        create(:task_svc_offering, :name => 'task4', :state => 'running', :service_offering => @service_offerings[0]),
+        create(:task_svc_instance, :name => 'task5', :state => 'running', :service_instance => @service_instances[3])
+      ]
+    end
+
+    describe "#load_running_tasks" do
+      it "loads only running tasks and orders them by source_id" do
+        tasks = subject.send(:load_running_tasks).to_a
+
+        expect(Task.count).to eq(5)
+        expect(tasks.size).to eq(3)
+        expect(tasks.first).to eq(@tasks[2])
+        expect(tasks.second).to eq(@tasks[4])
+        expect(tasks.third).to eq(@tasks[1])
+      end
+    end
+
+    describe "#service_instance_refresh" do
+      before do
+        Task.delete_all
+
+        @tasks = [
+          create(:task_svc_instance, :name => 'task1', :state => 'running', :service_instance => @service_instances[0]),
+          create(:task_svc_instance, :name => 'task2', :state => 'running', :service_instance => @service_instances[1])
+        ]
+      end
+
+      it "doesn't send tasks from unavailable Source" do
+        tasks = subject.send(:load_running_tasks)
+        expect(tasks.to_a.size).to eq(2)
+
+        expect(subject).to(receive(:source_available?).with(@tasks[0])).and_return(true)
+        expect(subject).to(receive(:source_available?).with(@tasks[1])).and_return(false)
+
+        payload = {
+          :source_id  => @sources[0].id.to_s,
+          :source_uid => @sources[0].uid.to_s,
+          :params     => [
+            :request_context => @tasks[0].forwardable_headers,
+            :source_ref      => @service_instances[0].source_ref,
+            :task_id         => @tasks[0].id.to_s
+          ]
+        }
+
+        expect(subject).to(receive(:send_payload).with(payload).and_return(nil))
+        expect(subject).not_to(receive(:send_payload).with(hash_including(:source_id => @sources[1].id.to_s)))
+
+        expect(subject).to(receive(:log_skipped_tasks).with({}))
+        expect(subject).to(receive(:log_skipped_tasks).with(@tasks[1].source_id => [@tasks[1].id.to_s]))
+
+        subject.send(:service_instance_refresh, tasks)
+      end
+
+      it "sends two payloads from 2 available Sources" do
+        @tasks << create(:task_svc_instance, :name => 'task3', :state => 'running', :service_instance => @service_instances[2])
+
+
+        tasks = subject.send(:load_running_tasks)
+        expect(tasks.to_a.size).to eq(3)
+
+        expect(subject).to receive(:source_available?).and_return(true).exactly(3).times
+
+        payload = {
+          :source_id  => @sources[0].id.to_s,
+          :source_uid => @sources[0].uid.to_s,
+          :params     => [{:request_context => @tasks[0].forwardable_headers,
+                           :source_ref      => @service_instances[0].source_ref,
+                           :task_id         => @tasks[0].id.to_s},
+                          {:request_context => @tasks[2].forwardable_headers,
+                           :source_ref      => @service_instances[2].source_ref,
+                           :task_id         => @tasks[2].id.to_s}]
+        }
+        expect(subject).to(receive(:send_payload).with(payload).and_return(nil))
+
+        payload = {
+          :source_id  => @sources[1].id.to_s,
+          :source_uid => @sources[1].uid.to_s,
+          :params     => [{:request_context => @tasks[1].forwardable_headers,
+                           :source_ref      => @service_instances[1].source_ref,
+                           :task_id         => @tasks[1].id.to_s}]
+        }
+        expect(subject).to(receive(:send_payload).with(payload).and_return(nil))
+
+        expect(subject).to(receive(:log_skipped_tasks).with({})).twice
+
+        subject.send(:service_instance_refresh, tasks)
+      end
+    end
   end
 end


### PR DESCRIPTION
Tasks from unavailable Source can't be scheduled for targeted_refresh svc. 

---

- **dependent**: https://github.com/RedHatInsights/e2e-deploy/pull/2295

---

[RHCLOUD-9589](https://issues.redhat.com/browse/RHCLOUD-9589)
