### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # topological_inventory-scheduler
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-scheduler.svg?branch=master)](https://travis-ci.org/RedHatInsights/topological_inventory-scheduler)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-scheduler.svg?branch=master)](https://travis-ci.com/RedHatInsights/topological_inventory-scheduler)
 [![Maintainability](https://api.codeclimate.com/v1/badges/ac8600418561b1337df8/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-scheduler/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/ac8600418561b1337df8/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-scheduler/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/topological_inventory-scheduler/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-scheduler/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.