### PR TITLE
Update Base Image to ubi8/ubi:8.3-227

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.3-227
 
 RUN dnf -y --disableplugin=subscription-manager module enable ruby:2.5 && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \


### PR DESCRIPTION
This PR Updates the UBI to 8.3-227 to fix CVE-2020-12049 and CVE-2019-2708

---

**Issue**: https://github.com/RedHatInsights/sources-api/issues/294